### PR TITLE
Include version number in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "Cogworks.Meganav",
+  "version": "1.0.1",
   "url": "https://github.com/thecogworks/meganav",
   "license": {
     "name": "MIT",


### PR DESCRIPTION
From [the npm docs](https://docs.npmjs.com/files/package.json)

`The most important things in your package.json are the name and version fields`

Unfortunately, there is no version in the package.json. While this doesn't directly cause any issues, it can cause bugs in some systems (e.g. if you use cmder for your windows CLI, errors are thrown when you navigate to the folder containing the package.json).

I'm not sure if it causes any problems anywhere else, but as this is required by default it seems best to just add it in.