### PR TITLE
Update item value via extend to maintain reference to original object

### DIFF
--- a/src/Cogworks.Meganav/Web/UI/App_Plugins/Meganav/Js/meganav.controller.js
+++ b/src/Cogworks.Meganav/Web/UI/App_Plugins/Meganav/Js/meganav.controller.js
@@ -1,4 +1,4 @@
-﻿function Meganav($scope, dialogService, meganavResource) {
+﻿function Meganav($scope, meganavResource) {
 
     $scope.items = [];
 
@@ -21,8 +21,7 @@
         openSettings(item, function (model) {
             // update item in scope
             // Assign new values via extend to maintain refs
-            console.log(model);
-            angular.extend(item, buildNavItem(model));
+            angular.extend(item, buildNavItem(model.value));
         });
     };
 
@@ -48,7 +47,7 @@
         });
     }
 
-    function openSettings(item, callback) {
+    function openSettings (item, callback) {
         // Assign value to new empty object to break refs
         // Prevent accidentally auto changing old values
         $scope.settingsOverlay = {
@@ -57,9 +56,9 @@
             show: true,
             value: angular.extend({}, item),
             submit: function (model) {
-              !callback || callback(model);
-              // close settings
-              closeSettings();
+                !callback || callback(model);
+                // close settings
+                closeSettings();
             }
         }
     }

--- a/src/Cogworks.Meganav/Web/UI/App_Plugins/Meganav/Js/meganav.controller.js
+++ b/src/Cogworks.Meganav/Web/UI/App_Plugins/Meganav/Js/meganav.controller.js
@@ -14,7 +14,7 @@
         dialogService.linkPicker({
             currentTarget: item,
             callback: function (item) {
-                item = buildNavItem(item);
+                angular.extend(item, buildNavItem(data));
             }
         });
     };

--- a/src/Cogworks.Meganav/Web/UI/App_Plugins/Meganav/Js/meganav.controller.js
+++ b/src/Cogworks.Meganav/Web/UI/App_Plugins/Meganav/Js/meganav.controller.js
@@ -12,8 +12,11 @@
 
     $scope.edit = function (item) {
         dialogService.linkPicker({
-            currentTarget: item,
-            callback: function (item) {
+            // Assign value to new empty object to break refs
+            // Prevent accidentally auto changing old values
+            currentTarget: angular.extend({}, item),
+            callback: function (data) {
+                // Assign new values via extend to maintain refs
                 angular.extend(item, buildNavItem(data));
             }
         });

--- a/src/Cogworks.Meganav/Web/UI/App_Plugins/Meganav/Views/settings.html
+++ b/src/Cogworks.Meganav/Web/UI/App_Plugins/Meganav/Views/settings.html
@@ -1,4 +1,4 @@
-﻿<div ng-controller="Cogworks.Meganav.MeganavSettingsController" class="umb-overlay-body">
+﻿<div ng-controller="Cogworks.Meganav.MeganavSettingsController" class="umb-overlay-body umb-modal">
 
     <umb-control-group label="@content_urls">
 


### PR DESCRIPTION
Titles are not being updated when editing an existing menu item. This is due to updating the value via basic assignment, which was breaking the reference to the original object (resulting in a new object being created, but never assigned to the main items array).

Using angular.extend to update the object ensures we replace the original values, instead of the entire object. Now our titles can update

Nav Items were also being automatically updated with any other changes, regardless of whether or not you clicked "select" or "cancel" in the link picker dialog. Changes will now only be applied when you press "select".