### PR TITLE
ValueConverter - Adds null/empty-string check

### DIFF
--- a/src/Cogworks.Meganav/ValueConverters/MeganavValueConverter.cs
+++ b/src/Cogworks.Meganav/ValueConverters/MeganavValueConverter.cs
@@ -25,6 +25,10 @@ namespace Cogworks.Meganav.ValueConverters
 
         public override object ConvertDataToSource(PublishedPropertyType propertyType, object source, bool preview)
         {
+            var sourceString = source?.ToString();
+            if (string.IsNullOrWhiteSpace(sourceString))
+                return null;
+
             var preValues = PreValueHelper.GetPreValues(propertyType.DataTypeId);
 
             if (preValues.ContainsKey("removeNaviHideItems"))
@@ -34,7 +38,7 @@ namespace Cogworks.Meganav.ValueConverters
 
             try
             {
-                var items = JsonConvert.DeserializeObject<IEnumerable<MeganavItem>>(source.ToString());
+                var items = JsonConvert.DeserializeObject<IEnumerable<MeganavItem>>(sourceString);
 
                 return BuildMenu(items);
             }


### PR DESCRIPTION
If a MegaNav value is emptied out in the CMS, then the `source` value is an empty string. The empty string is then attempted to be deserialized to a list of MeganavItem items - which would be `null`. Then the null-reference is passed to the `BuildMenu` method, which then `ToList()` is immediately called - throwing an exception.

This exception is caught and logged, but it is preventable by adding a null/empty-string check upfront - saves the extra work.